### PR TITLE
Unit 7 lectures 5 + 6 updates

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,8 +1,8 @@
 # This file is machine-generated - editing it directly is not advised
 
-julia_version = "1.11.6"
+julia_version = "1.11.7"
 manifest_format = "2.0"
-project_hash = "55b2e26683163f9a632fb3dd40d334aef3b4f676"
+project_hash = "629ef1254d79e1c1970f988495a491e86375bbb2"
 
 [[deps.ADTypes]]
 git-tree-sha1 = "be7ae030256b8ef14a441726c4c37766b90b93a3"
@@ -273,6 +273,16 @@ weakdeps = ["SparseArrays"]
 
     [deps.ChainRulesCore.extensions]
     ChainRulesCoreSparseArraysExt = "SparseArrays"
+
+[[deps.Chairmarks]]
+deps = ["Printf", "Random"]
+git-tree-sha1 = "9a49491e67e7a4d6f885c43d00bb101e6e5a434b"
+uuid = "0ca39b1e-fe0b-4e98-acfc-b1656634c4de"
+version = "1.3.1"
+weakdeps = ["Statistics"]
+
+    [deps.Chairmarks.extensions]
+    StatisticsChairmarksExt = ["Statistics"]
 
 [[deps.CloseOpenIntervals]]
 deps = ["Static", "StaticArrayInterface"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,8 @@
 [deps]
+AliasTables = "66dad0bd-aa9a-41b7-9441-69ab47430ed8"
 Arpack = "7d9fca2a-8960-54d3-9f78-7d1dccf2cb97"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+Chairmarks = "0ca39b1e-fe0b-4e98-acfc-b1656634c4de"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/markdown/lecture-unit-7.jmd
+++ b/markdown/lecture-unit-7.jmd
@@ -1617,14 +1617,14 @@ A file is loaded by using `include` such as `include("file.jl")`, which evaluate
 
 Packages are designed for sharing code - either open-source code in the community, or private code within an organization. A package has a small set of rules to help the Julia and the package manager to load your code:
 
- * A package `Foo` must contain a module defined called `Foo` in the file `src/Foo.jl`.
- * The root directory must contain a `Package.toml` file with the name of the package and a UUID of the package, plus any *direct* package dependencies.
+* A package `Foo` must define a module called `Foo` in the file `src/Foo.jl`.
+* The root directory must contain a `Package.toml` file with the name of the package and a UUID of the package, plus any *direct* package dependencies.
 
 There are a number of optional things that a package might contain, which the package manager knows how to deal with. Most importantly:
 
- * A git repository (tracked by the package registry).
- * A test suite (Julia and github can help you automate testing).
- * Optionally, a `Manifest.toml` file (containing the precise version of every package used as well as all the *indirect* package dependencies).
+* A git repository (tracked by the package registry).
+* A test suite with entry point `test/runtests.jl` (Julia and github can help you automate testing) 
+* Optionally, a `Manifest.toml` file (containing the precise version of every package used as well as all the *indirect* package dependencies).
 
 When you use a `Manifest.toml` you are "locking" your code to use certain versions of packages. Otherwise when you install packages you will get the latest version compatible version of Julia and other dependencies. While using the latest version of code is generally good, occassiionally packages introduce bugs or change the API in a breaking way, and for complex, production-grade code it is necessary to have a high degree of stability to ensure your code continues to function and doesn't break unexpectedly. This issue becomes more important the larger the codebase and number of dependencies.
 
@@ -1652,7 +1652,7 @@ On the technical side, each change to the code has a chance of breaking some fun
 
 On the human side, it's ideal to know about any broken code right away before you forget about the details of the changes you were making. It's far easier, faster, cheaper and *just more fun* to get the code correct at the time rather than having to hunt down a problem later.
 
-If you have a multi-person project, tests give the project scalability: new contributors can add code to the project without breaking things, and the burden on the maintainers to check that new code is much less because the tests are a proof that things still work after some new change. And remember: in three years time it's likely you'll have forgotten all the details of your project - *you* become the new contributor but your past-self isn't around anymore to review your new code! Even for single person projects the tests keep you honest and hold your hand as you get back into changing your old code and remembering how it works.
+If you have a multi-person project, tests give the project scalability: new contributors can add code to the project without breaking things, and the burden on the maintainers to check that new code is much less because the tests are a proof that things still work after some new change. And remember: in three years time it's likely you'll have forgotten many details of your project - *you* become the new contributor but your past-self isn't around anymore to review your new code. Even for single person projects the tests keep you honest and hold your hand as you get back into changing your old code and remembering how it works.
 
 ### When to write tests, how many tests, what flavour of tests?
 
@@ -1686,10 +1686,10 @@ Here's a grab bag of packages developed by me (Claire Foster) and collaborators.
 * A package for underscore placeholder syntax [Underscores.jl](https://github.com/c42f/Underscores.jl) (you may find this useful in the next unit)
 
 We'll talk about the open source maintainence workflow with reference to a relatively old package `PlyIO` (started in Julia version 0.5 - before Project.toml existed!), including:
-* Issues / bug reports (as a simple example, https://github.com/JuliaGeometry/PlyIO.jl/issues/21)
-* Pull Requests (https://github.com/JuliaGeometry/PlyIO.jl/pull/22)
-* Testing for Continuous Integration (https://github.com/JuliaGeometry/PlyIO.jl/actions/runs/11320934127/job/31479240290?pr=22)
-* Releasing new versions in the General registry (https://github.com/JuliaGeometry/PlyIO.jl/commit/a19d73080cbac01a2d4ef91ce042f39e4cbf2045)
+* Issues / bug reports (as a simple example, <https://github.com/JuliaGeometry/PlyIO.jl/issues/21>)
+* Pull Requests (<https://github.com/JuliaGeometry/PlyIO.jl/pull/22>)
+* Testing for Continuous Integration (<https://github.com/JuliaGeometry/PlyIO.jl/actions/runs/11320934127/job/31479240290?pr=22>)
+* Releasing new versions in the General registry (<https://github.com/JuliaGeometry/PlyIO.jl/commit/a19d73080cbac01a2d4ef91ce042f39e4cbf2045>)
 
 Time permitting, we may also discuss the work that goes into developing such packages and some history and design philosopy.
 
@@ -1737,9 +1737,9 @@ $$
 p(\mathbf{x}) \propto e^{- E_{\mathbf{x}} / k_B T}
 $$
 
-The state space for $\mathbf{x}$ may be huge. Calculating the constant of proportionality (the "partition function") analytically is difficult but with it you can trivially calculate the macroscopic quantities of the system (mean energy, entropy, etc) via differentiation. Similarly, if we can sample the "microstates" it is straightforward to estimate the physical properties. So this is our goal here.
+The state space for $\mathbf{x}$ may be huge. Calculating the constant of proportionality (the "partition function" $Z = \sum_{\mathbf{x}} e^{- E_{\mathbf{x}} / k_B T}$) analytically is difficult but with it you can calculate the macroscopic quantities of the system (mean energy, entropy, etc) via simple differentiation. Similarly, if we can sample the "microstates" it is straightforward to estimate the physical properties. So this is our goal here.
 
-In such a case, there are algorithms for generating random variables that are approximaltly distributed according to the target distribution even though the normalizing constant is not known and can only be computed via integration which quickly becomes infeasible as the dimensions grow (see Unit 3). A suite of algorithms is known is MCMC, with a famous case being the [Metropolis–Hastings algorithm](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm), allows to still generate random variables from the distribtuion, even without knowing $K$.
+In such a case, there are algorithms for generating random variables that are approximately distributed according to the target distribution even though the normalizing constant is not known and can only be computed via integration which quickly becomes infeasible as the dimensions grow (see Unit 3). A suite of algorithms is known is MCMC, with a famous case being the [Metropolis–Hastings algorithm](https://en.wikipedia.org/wiki/Metropolis%E2%80%93Hastings_algorithm), allows to still generate random variables from the distribtuion, even without knowing $K$.
 
 MCMC algorithms implictly construct a Markov chain that has a steady-state distribution which is equal to the target probability distribution. Then, generation of random sequences from this new Markov chain allows us to approximately sample the target distribution. Without going into the details of the algorithm, let's see this in action in the context of Bayesian statistics.
 
@@ -1787,41 +1787,41 @@ alpha, beta = 8, 2
 prior(theta) = pdf(Gamma(alpha, 1/beta), theta)
 data = [2,1,0,0,1,0,2,2,5,2,4,0,3,2,5,0]
 
-like(theta) = *([pdf(Poisson(theta),x) for x in data]...)
-posteriorUpToK(theta) = like(theta)*prior(theta)
+likelihood(theta) = prod(pdf(Poisson(theta),x) for x in data)
+posteriorUpToK(theta) = likelihood(theta)*prior(theta)
 ```
 
-Now an MCMC technique (with details omitted here) uses a proposal density (`foldedNormalPDF` here) and implements the `sampler()` function which magically samples from the posterior (unormalized probability distribution).
+Now an MCMC technique (the aforementioned Metropolis-Hastings algorithm) uses a proposal density (`foldedNormalPDF` here) and implements the `sampler()` function which magically samples from the posterior (unormalized probability distribution).
 
 ```julia
 sig = 0.5
-foldedNormalPDF(x,mu) = (1/sqrt(2*pi*sig^2))*(exp(-(x-mu)^2/2sig^2)
-                                                + exp(-(x+mu)^2/2sig^2))
+foldedNormalPDF(x, mu) = (1/sqrt(2*pi*sig^2)) *
+                         (exp(-(x-mu)^2/(2*sig^2)) + exp(-(x+mu)^2/(2*sig^2)))
 foldedNormalRV(mu) = abs(rand(Normal(mu,sig)))
 
-function sampler(piProb,qProp,rvProp)
+# Metropolis-Hastings sampler
+# NOTE: `posteriorDensity` is unnormalized (`proposalDensity` may be too)
+function sampler(posteriorDensity, proposalDensity, generateProposal)
     theta = 1
     warmN, N = 10^5, 10^6
     samples = zeros(N-warmN)
 
     for t in 1:N
-        while true
-            lamTry = rvProp(theta)
-            L = piProb(lamTry)/piProb(theta)
-            H = min(1,L*qProp(theta,lamTry)/qProp(lamTry,theta))
-            if rand() < H
-                theta = lamTry
-                if t > warmN
-                    samples[t-warmN] = theta
-                end
-                break
-            end
+        thetaTry = generateProposal(theta)
+        L = posteriorDensity(thetaTry)/posteriorDensity(theta)
+        H = L * proposalDensity(theta,thetaTry) / proposalDensity(thetaTry,theta)
+        if rand() < H
+            # Accept proposal
+            theta = thetaTry
+        end
+        if t > warmN
+            samples[t-warmN] = theta
         end
     end
     return samples
 end
 
-mcmcSamples = sampler(posteriorUpToK,foldedNormalPDF,foldedNormalRV);
+mcmcSamples = sampler(posteriorUpToK, foldedNormalPDF, foldedNormalRV);
 ```
 
 If we want now a point estimate we can use the mean:
@@ -1840,10 +1840,10 @@ thetaRange = 0:0.01:10
 plot!(thetaRange, prior.(thetaRange), 
 	c=:blue, label="Prior distribution")
 
-closedFormPosterior(lam)=pdf(Gamma(alpha + sum(data),1/(beta+length(data))),lam)
+closedFormPosterior(theta) = pdf(Gamma(alpha + sum(data),1/(beta+length(data))), theta)
 plot!(thetaRange, closedFormPosterior.(thetaRange), 
-	c=:red, label="Posterior distribution", 
-	xlims=(0, 10), ylims=(0, 1.2),
+	c=:red, label="True posterior distribution", 
+	xlims=(0, 10), ylims=(0, 1.25),
     xlabel=L"\theta",ylabel="Density")
 ```
 
@@ -1854,9 +1854,9 @@ In this simple example, MCMC is not needed. But in other examples, MCMC or more 
 
 # Other simulations
 
-In addition to discrete event simulation, there are many other forms of simulations. For example you may consider simple Markov chain simulations as appearing in HW2. But you can also consider [https://en.wikipedia.org/wiki/Continuous-time_Markov_chain](Continuous-time Markov chain) which can be simulated via the [Doob-Gillespie algorithm](https://en.wikipedia.org/wiki/Gillespie_algorithm). In such models the state space is represented by a countable (or finite) set, and at any point of time there is an instentanious chance from a transition from one state to another. 
+In addition to discrete event simulation, there are many other forms of simulations. For example you may consider simple Markov chain simulations as appearing in HW2. But you can also consider [Continuous-time Markov chain](https://en.wikipedia.org/wiki/Continuous-time_Markov_chain) which can be simulated via the [Doob-Gillespie algorithm](https://en.wikipedia.org/wiki/Gillespie_algorithm). In such models the state space is represented by a countable (or finite) set, and at any point of time there is an instentanious chance from a transition from one state to another. 
 
-As an example consider a [stochastic SEIR epidemic model](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology) with transition rates,
+As an example consider a [stochastic SEIR epidemic model](https://en.wikipedia.org/wiki/Compartmental_models_in_epidemiology) - (also less-confusingly called "SLIR") with the following transitions between suceptible, exposed ("latently infected"), infected and removed states:
 
 $$
 \begin{aligned}
@@ -1876,10 +1876,13 @@ beta, delta, gamma = 0.25, 0.4, 0.1
 initialInfect = 0.025
 M = 1000
 I0 = Int(floor(initialInfect*M))
-N = 30
 
-function simulateSIRDoobGillespie(beta,delta,gamma,I0,M,T)
-    t, S, E, I, R = 0.0, M-I0, 0, I0, 0
+function simulateSIRDoobGillespie(beta, delta, gamma, I0, M, T)
+    t = 0.0
+    S = M-I0
+    E = 0
+    I = I0
+    R = 0
     tValues, sValues, eValues, iValues, rValues = [0.0], [S], [E], [I], [R]
     while t<T
         infectionRate = beta*I*S
@@ -1906,14 +1909,15 @@ end
 tV,sV,eV,iV,rV = simulateSIRDoobGillespie(beta/M,delta,gamma,I0,M,Inf)
 lastT = tV[end]
 
+N = 30
 finals = [simulateSIRDoobGillespie(beta/M,delta,gamma,I0,M,Inf)[5][end] 
-                for _ in 1:N]/M
+          for _ in 1:N]/M
 
-p1 = plot(tV,sV/M,label = "Susceptible", c=:green)
-plot!(tV,eV/M,label = "Exposed", c=:blue)
-plot!(tV,iV/M,label = "Infected",c=:red)
-plot!(tV,rV/M,label = "Removed", c=:yellow,
-    xlabel = "Time", ylabel = "Proportion",
-    legend = :topleft, xlim = (0,lastT*1.05))
-scatter!(lastT*1.025*ones(N),finals, c = :yellow,label= "Final Infected")
+p1 = plot(tV,sV/M,label = "Susceptible")
+plot!(tV,eV/M, label = "Exposed")
+plot!(tV,iV/M, label = "Infected")
+plot!(tV,rV/M, label = "Removed", c = :purple,
+      xlabel = "Time", ylabel = "Proportion",
+      legend = :topleft, xlim = (0,lastT*1.05))
+scatter!(lastT*1.025*ones(N),finals, c = :purple, label="Final Infected")
 ```

--- a/markdown/lecture-unit-7.jmd
+++ b/markdown/lecture-unit-7.jmd
@@ -725,7 +725,6 @@ Instead of writing a specialized discrete event simulation code for each specifi
 
 ```julia
 using DataStructures
-import Base: isless
 
 abstract type Event end
 abstract type State end
@@ -737,7 +736,7 @@ struct TimedEvent
 end
 
 # Comparison of two timed events - this will allow us to use them in a heap/priority-queue
-isless(te1::TimedEvent, te2::TimedEvent) = te1.time < te2.time
+Base.isless(te1::TimedEvent, te2::TimedEvent) = te1.time < te2.time
 
 """
     new_timed_events = process_event(time, state, event)
@@ -940,17 +939,17 @@ A heap is based on an **(almost) complete balanced binary tree** data structure.
 
 ![Almost Complete Binary Tree](../web_img/tree1.jpg)
 
-Here we numbered the node in binary sequentially where the root is $1$, it's two leafs are $10$, and $11$, the third layer has $100$, $101$, $110$, and $111$, and so fourth. In this example there are $12$ nodes all together. Notice they are compacted on the final layer to the left. 
+Here we numbered the node in binary sequentially where the root is $1$, its two leaves are $10$, and $11$, the third layer has $100$, $101$, $110$, and $111$, and so fourth. In this example there are $12$ nodes all together. Notice they are compacted on the final layer to the left. 
 
 If we had $1$, $3$, $7$, $15$, $31$, or $63$ nodes (etc.) the tree would be complete. Otherwise it is in general called almost complete. 
 
-A nice thing about this layout of the tree is that the **path** to any node is determined by it's binary representation. To do this omit the MSB (most significant bit) of the number of the node. Then we take the bits from left to right (starting one bit to the right of the MSB), and consider "0" as going left, and "1" as going right. So for example the path to the node $1010$ goes left $\rightarrow$ right $\rightarrow$ left.
+A nice thing about this layout of the tree is that the **path** to any node is determined by its binary representation. To do this omit the MSB (most significant bit) of the number of the node. Then we take the bits from left to right (starting one bit to the right of the MSB), and consider "0" as going left, and "1" as going right. So for example the path to the node $1010$ goes left $\rightarrow$ right $\rightarrow$ left.
 
 Almost complete binary arrays are special in that they can actually be laid out in memory sequentially:
 
 ![Almost Complete Binary Tree in memory](../web_img/tree2.png)
 
-With this layout you can easily find the array index **left child**, **right child**, or **parent** of each node. In fact, there is $O(1)$ access to any numbered node. This differs from most other trees (not necessarily almost complete binary trees) where a **dangled** implementation is needed. In such a dangled implementation, pointers or references need to be kept between nodes. Here is for example a struct for such a node which keeps a string inside it:
+With this layout you can easily find the array index **left child**, **right child**, or **parent** of each node. In fact, there is $O(1)$ access to any numbered node. This differs from many other trees (not necessarily almost complete binary trees) where a **linked** implementation is needed if the tree is to be mutated efficiently. In such a linked implementation, pointers or references need to be kept between nodes. Here is for example a struct for such a node which keeps a string inside it:
 
 ```julia
 mutable struct Node
@@ -963,7 +962,14 @@ mutable struct Node
 end
 ```
 
-Since in this course we didn't get a chance to see such dangled implementations elsewhere, and since they are ubiquitous with classical and useful data structures such as general balanced trees, linked lists, graphs, and more, we now present an implementation of such a complete binary tree using the `Node` struct above. We then use it for a heap, which we describe below. 
+Since in this course we didn't get a chance to see such linked implementations
+elsewhere, and since they are ubiquitous with classical and useful data
+structures such as general balanced trees, linked lists, graphs, and more, we
+now present an implementation of such a complete binary tree using the `Node`
+struct above. We then use it for a heap, which we describe below. We emphasize
+that this is strictly for pedagogical purposes and in practice heap updates are
+restricted enough that an array based implementation is very efficient and
+should be preferred for production code.
 
 This specific case stores `value` elements of type `String`. However this can be generalized to store any types of values.
 
@@ -1020,9 +1026,7 @@ end
 Now lets implement the most important methods of this tree: `push!()` and `pop!()`. The key logic in these functions is to find the "next available spot" in push and to put an element there. Similarly in `pop!()` we remove the element from the last spot and put it in place of the root, which is removed:
 
 ```julia
-import Base: push!
-
-function push!(tree::BalancedBinaryTree, value::String)::BalancedBinaryTree
+function Base.push!(tree::BalancedBinaryTree, value::String)::BalancedBinaryTree
     new_node = Node(value)
     
     # If tree is empty just add a root
@@ -1063,8 +1067,7 @@ end
 ```
 
 ```julia
-import Base: pop!
-function pop!(tree::BalancedBinaryTree)::String
+function Base.pop!(tree::BalancedBinaryTree)::String
     ret_val = tree.root.value
     
     # if there is only the root then remove it
@@ -1082,24 +1085,24 @@ function pop!(tree::BalancedBinaryTree)::String
     while true
         if num & mask != 0  # If bit is "1" then go right
             if mask == 1
-                node_to_replace_with_root = current_node.rchild
+                new_root = current_node.rchild
                 current_node.rchild = nothing
-                node_to_replace_with_root.parent = nothing
-                node_to_replace_with_root.rchild = tree.root.rchild
-                node_to_replace_with_root.lchild = tree.root.lchild
-                tree.root = node_to_replace_with_root
+                new_root.parent = nothing
+                new_root.rchild = tree.root.rchild
+                new_root.lchild = tree.root.lchild
+                tree.root = new_root
                 break
             else  # not last one on the right
                 current_node = current_node.rchild 
             end
         else  # If here then bit is "0" and go left
             if mask == 1
-                node_to_replace_with_root = current_node.lchild
+                new_root = current_node.lchild
                 current_node.lchild = nothing
-                node_to_replace_with_root.parent = nothing
-                node_to_replace_with_root.rchild = tree.root.rchild
-                node_to_replace_with_root.lchild = tree.root.lchild
-                tree.root = node_to_replace_with_root                
+                new_root.parent = nothing
+                new_root.rchild = tree.root.rchild
+                new_root.lchild = tree.root.lchild
+                tree.root = new_root                
                 break
             else  # not last one on the left
                 current_node = current_node.lchild
@@ -1141,7 +1144,7 @@ println("Now the tree is:")
 print(tree)
 ```
 
-This is all nice and good, but now lets use this type of tree for a **heap**. The heap is an almost complete binary tree with values that can be compared and with the critical **partial order**: Each node is larger (not smaller) than its children. This then allows to pop in $O(1)$ time since the maximum is the root. But it also allows to insert in $O(log~n)$ time!  
+This is all nice and good, but now lets use this type of tree for a **heap**. The heap is an almost complete binary tree with values that can be compared and with the critical **partial order**: Each node is larger (not smaller) than its children. This then allows to pop in $O(1)$ time since the maximum is the root. But it also allows to insert in $O(log~n)$ time (Q: why $log(n)$?)
 
 Let's look at an implementation using the tree we constructed above:
 
@@ -1176,14 +1179,14 @@ end
 And here is how we use it to push:
 
 ```julia
-function push!(heap::MaxHeap, value::String)::MaxHeap
+function Base.push!(heap::MaxHeap, value::String)::MaxHeap
     push!(heap.tree, value)
     sift_up!(last_node(heap.tree))
     return heap
 end
 ```
 
-Note that it uses a way to find the "last node" of the tree, so we'll need that in the tree (it uses similar logic to push! of the tree and would have been simpler in an array implementation:
+Note that it uses a way to find the "last node" of the tree, so we'll need that as well (it uses similar logic to `push!` and would have been simpler in an array implementation):
 
 ```julia
 function last_node(tree::BalancedBinaryTree)::Node
@@ -1253,7 +1256,7 @@ end
 We can now use it in `pop!`:
 
 ```julia
-function pop!(heap::MaxHeap)::String
+function Base.pop!(heap::MaxHeap)::String
     ret_val = pop!(heap.tree)
     heap.tree.root !== nothing && sift_down!(heap.tree.root)
     return ret_val
@@ -1281,7 +1284,7 @@ push!(heap, "McEwen, John")
 push!(heap, "Holt, Harold")
 
 println("Tree of heap:")
-print(heap)
+println(heap)
 
 println("Printing in reverse alphabetical order: ")
 
@@ -1311,7 +1314,7 @@ A module is a "namespace" - it is a place to hold variables, functions and types
  * `Base` is the standard library defining much of the functionality for arrays, dictionaries, strings, etc.
  * `Main` is created at startup and by default all the variables and function you define in the REPL lives here.
 
-You can a new module with the `module` keyword:
+You can define a new module with the `module` keyword:
 
 ```julia
 module MyModule
@@ -1339,7 +1342,7 @@ By default, the module will be `using Base` (this can be removed by using `barem
 
 Modules have a set of `export`s. While some code is intended to be "internal" to the module, the export statement signals which types, functions and variables are intended for users of the module, and things marked with `export` are automatically imported with the `using` statement. Sometimes you want to parts of the package as public without exporting them into the user's namespace - for this you can use the `public` keyword (new in Julia 1.11).
 
-By default, `using` and `import` will consult the package manager to look up the name (we will discuss this later). To avoid this and use a locally defined module in the current scope prefix with a single `.`, such as `using .MyModule`. Since modules have a `parentmodule()`, you can navigate to any other module in the hierarchy by adding more `.`s, such as `using ..MyModule`.
+By default, `using` and `import` will consult the package manager to look up the name (we will discuss this later). To avoid this and use a locally defined module in the current scope, prefix the module name with a single `.` such as `using .MyModule`. Since modules have a `parentmodule()`, you can navigate to any other module in the hierarchy by adding more `.`s, such as `using ..MyModule`.
 
 A good module name describes the topic covered by the module. The module name shouldn't clash with one of it's exports, so if the module is about a particular datatype it is common to pluralize it (e.g. the `DataFrames` module deals with the `DataFrame` type).
 
@@ -1358,6 +1361,8 @@ module MaxHeaps
 # Generally, put the exports at the top so they are easy to discover
 export MaxHeap
 
+# Module "top level" statements are executed in order so we define
+# types before they're used in the method signatures below
 mutable struct Node{T}
     parent::Union{Node{T}, Nothing}
     lchild::Union{Node{T}, Nothing}
@@ -1522,24 +1527,24 @@ function Base.pop!(tree::BalancedBinaryTree)::String
     while true
         if num & mask != 0  # If bit is "1" then go right
             if mask == 1
-                node_to_replace_with_root = current_node.rchild
+                new_root = current_node.rchild
                 current_node.rchild = nothing
-                node_to_replace_with_root.parent = nothing
-                node_to_replace_with_root.rchild = tree.root.rchild
-                node_to_replace_with_root.lchild = tree.root.lchild
-                tree.root = node_to_replace_with_root
+                new_root.parent = nothing
+                new_root.rchild = tree.root.rchild
+                new_root.lchild = tree.root.lchild
+                tree.root = new_root
                 break
             else  # not last one on the right
                 current_node = current_node.rchild 
             end
         else  # If here then bit is "0" and go left
             if mask == 1
-                node_to_replace_with_root = current_node.lchild
+                new_root = current_node.lchild
                 current_node.lchild = nothing
-                node_to_replace_with_root.parent = nothing
-                node_to_replace_with_root.rchild = tree.root.rchild
-                node_to_replace_with_root.lchild = tree.root.lchild
-                tree.root = node_to_replace_with_root                
+                new_root.parent = nothing
+                new_root.rchild = tree.root.rchild
+                new_root.lchild = tree.root.lchild
+                tree.root = new_root                
                 break
             else  # not last one on the left
                 current_node = current_node.lchild
@@ -1617,15 +1622,25 @@ Packages are designed for sharing code - either open-source code in the communit
 
 There are a number of optional things that a package might contain, which the package manager knows how to deal with. Most importantly:
 
- * A `Manifest.toml` file (containing the precise version of every package used as well as all the *indirect* package dependencies).
  * A git repository (tracked by the package registry).
  * A test suite (Julia and github can help you automate testing).
+ * Optionally, a `Manifest.toml` file (containing the precise version of every package used as well as all the *indirect* package dependencies).
 
-When you use a `Manifest.toml` you are "locking" your code to use certain versions of packages. Otherwise when you install packages you will get the latest version compatible version of Julia and other dependencies. While using the latest version of code is generally good, occassiionally packages introduce bugs or change the API in a breaking way, and for complex, production-grade code it is necessary to have a high degree of stability to ensure your code continues to function and doesn't break unexpectedly. (This issue becomes more important the larger the codebase and number of dependencies).
+When you use a `Manifest.toml` you are "locking" your code to use certain versions of packages. Otherwise when you install packages you will get the latest version compatible version of Julia and other dependencies. While using the latest version of code is generally good, occassiionally packages introduce bugs or change the API in a breaking way, and for complex, production-grade code it is necessary to have a high degree of stability to ensure your code continues to function and doesn't break unexpectedly. This issue becomes more important the larger the codebase and number of dependencies.
 
 ## Creating packages - demonstration
 
 Let's construct a package live and edit its code! We'll use PkgTemplates.jl and Revise.jl along with the REPL for a smooth package development experience.
+
+```julia; eval = false
+using PkgTemplates
+
+# `Template` has a lot of options
+template = Template(user="my_github_user", plugins=[!CompatHelper, !TagBot])
+
+# Generate the new package using the template:
+package_dir = template("MaxHeaps")
+```
 
 ## Package Tests
 


### PR DESCRIPTION
Minor updates to clean up heap code

* Make some variable naming less confusing
* Make adding methods to Base functions explicit rather than implicit
* Add tiny bit of example code for package creation

Also fix bugs in MCMC implementation + tweaks for code readability

The previous example MCMC implementation (MCMC via Metropolis-Hastings)
was actually quite buggy - when rejecting a step it didn't keep the
existing value of the state variable theta as the next state in the
markov chain, but kept retrying until acceptance.

This significantly underestimates the value of the posterior near the
maximum of the distribution (which you could see in the example graph).